### PR TITLE
cope with setuptools >= `61.0.0`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ pp
 history.yaml
 
 bunker.egg-info/
+
+.idea

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,21 @@ with open("README.md", "r") as fh:
 setup(
     name='bunker',
     version='0.1',
+    py_modules=[
+        "chain",
+        "chrono",
+        "conn",
+        "main",
+        "make_captcha",
+        "objstruct",
+        "persist",
+        "policy",
+        "status",
+        "torsion",
+        "utils",
+        "version",
+        "webapp",
+    ],
     license='MIT+CC',
     python_requires='>=3.7.0',
     url='https://github.com/Coldcard/ckbunker',
@@ -43,5 +58,4 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Operating System :: MacOS :: MacOS X',
     ],
-    packages=[],
 )


### PR DESCRIPTION
* context: https://github.com/pypa/setuptools/issues/4013
* all python installation with >= `61.0.0` will create broken package after `pip install -e .` with error `ModuleNotFoundError`
* this change is backward-compatible and tested with older setuptools
* it would maybe be better to organize repo "correctly" as python package (i.e creating subdirectory ckbunker with `__init__.py`), then we can just list `package=["ckbunker"]` in `setup.py`